### PR TITLE
Fix wrong test

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -71,9 +71,9 @@ TEST(lab2,task1_2)
 TEST(lab2,task1_3)
 {
 	const size_t n = 6;
-	char* val[n]{(char*)"ffff", (char*)"fff2", (char*)"f", (char*)"ff", (char*)"vvv", (char*)"fffrr"};
+	char* val[n]{(char*)"ffff", (char*)"fff222", (char*)"f", (char*)"ff", (char*)"vvv", (char*)"fffrr"};
 	lab2::msort(val, n);
-    char* expected[n]{(char*)"f", (char*)"ff", (char*)"vvv", (char*)"fff2", (char*)"ffff", (char*)"fffrr"};
+    char* expected[n]{(char*)"f", (char*)"ff", (char*)"vvv", (char*)"ffff", (char*)"fffrr", (char*)"fff222"};
     
     for(size_t i = 0; i < n; i++)
 		EXPECT_EQ(expected[i], val[i]);


### PR DESCRIPTION
The task condition does not define behavior for strings of the same length